### PR TITLE
correct issue that caused domain name to be none

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -59,11 +59,13 @@ def add_indicator(url, indicator_type, indicator_content):
 def add_ip_address(domain_name):
     ip_indicators = []
     if domain_name.startswith("https://"):
-        domain_name = domain_name[8:]
+        host_name = domain_name[8:]
+    else:
+        host_name = domain_name
 
     try:
         # Resolve the domain name to an IP address
-        ip_address = socket.gethostbyname(domain_name)
+        ip_address = socket.gethostbyname(host_name)
         ip_indicators.append(
             {
                 "indicator_type": "ip",


### PR DESCRIPTION
Passing in the domain name with `https://` stripped causes the parsed url to have a `netloc` variable of None. This causes the resulting domain id pulled from `get_domain_name` to be None.

```
parsed url: ParseResult(scheme='', netloc='', path='www.rt.com', params='', query='', fragment='')
```

The issue is resolved by passing in the domain name as it originally exists, and using a separate variable `host_name` for the socket function (which requires `https://` to be stripped).